### PR TITLE
Disabled logging out while in fight when using bed

### DIFF
--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -124,6 +124,11 @@ bool BedItem::trySleep(Player* player)
 		return false;
 	}
 
+	if (player->hasCondition(CONDITION_INFIGHT)){
+		player->sendCancelMessage(RETURNVALUE_YOUMAYNOTLOGOUTDURINGAFIGHT);
+		return false;
+	}
+
 	if (sleeperGUID != 0) {
 		if (Item::items[id].transformToFree != 0 && house->getOwner() == player->getGUID()) {
 			wakeUp(nullptr);


### PR DESCRIPTION
I noticed that it was possible to logout while being in a fight if you logout by using a bed.