### PR TITLE
Fixing field bug and other small stuff

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -179,7 +179,7 @@ ReturnValue Combat::canDoCombat(Creature* caster, Tile* tile, bool aggressive)
 		return RETURNVALUE_NOTENOUGHROOM;
 	}*/
 
-	if (tile->hasProperty(CONST_PROP_IMMOVABLEBLOCKPATH)) {
+	if (tile->hasProperty(CONST_PROP_IMMOVABLEBLOCKPATH) && tile->hasProperty(CONST_PROP_IMMOVABLENOFIELDBLOCKPATH)) {
 		return RETURNVALUE_NOTENOUGHROOM;
 	}
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -756,7 +756,7 @@ bool ConditionSoul::setParam(ConditionParam_t param, int32_t value)
 
 bool ConditionDamage::setParam(ConditionParam_t param, int32_t value)
 {
-	bool ret = Condition::setParam(param, value);
+	Condition::setParam(param, value);
 
 	switch (param) {
 		case CONDITION_PARAM_OWNER:

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -57,6 +57,7 @@ static constexpr auto CLIENT_VERSION_STR = "7.72";
 #pragma warning(disable:4267) // 'var' : conversion from 'size_t' to 'type', possible loss of data
 #pragma warning(disable:4351) // new behavior: elements of array will be default initialized
 #pragma warning(disable:4458) // declaration hides class member
+#pragma warning(disable:4018) // signed/unsigned mismatch
 #endif
 
 #define strcasecmp _stricmp


### PR DESCRIPTION
https://github.com/TwistedScorpio/Nostalrius/commit/b7a150f324d1c00b75e5a7d532d3ca7ab672cb2e
Introduced bug with fields, you couldnt cast spells on fields, this pull request fixes that, also disables warnings about signed/unsigned mismatch and one other warning.

Was bored so here I am.